### PR TITLE
feat(helm-chart/ingress): auto-create tls-block when using cert-manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
 [[package]]
 name = "dkregistry"
 version = "0.5.1-alpha.0"
+source = "git+https://github.com/mcronce/dkregistry-rs.git#23f806c0d0408fee5a6efac754ce0e40c241d9f2"
 dependencies = [
  "async-stream",
  "base64 0.21.2",

--- a/dist/helm/templates/ingress.yaml
+++ b/dist/helm/templates/ingress.yaml
@@ -25,14 +25,13 @@ spec:
   {{- if $new }}
   ingressClassName: {{ required "If ingress.enabled is set to true, ingress.class is required" .Values.ingress.class | quote }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if or .Values.ingress.tls (hasKey .Values.ingress.annotations "kubernetes.io/tls-acme") }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . }}
-      {{- end }}
-      secretName: {{ .secretName }}
+    {{- if hasKey .Values.ingress.annotations "kubernetes.io/tls-acme" }}
+    - hosts: {{ .Values.ingress.hosts | toYaml | nindent 8 }}
+      secretName: {{ printf "%s-tls" .Release.Name }}
+    {{- else }}
+      {{- toYaml (list .Values.ingress.tls) | nindent 4 }}
     {{- end }}
   {{- end }}
   rules:


### PR DESCRIPTION
This makes it easier for cert-manger users