### PR TITLE
initial attempt at adding proper cri-o support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Restart Docker and it will start pulling images from `docker.io` through `oci-re
 ## `containerd`
 `containerd` provides a mechanism for mirroring any registry you want, and sends the upstream registry as a querystring parameter in all its requests.  This means that we can mirror any number of registries to `containerd` with a single instance of `oci-registry`.
 
+## `cri-o`
+`cri-o` requires defining each registry you want to mirror, but you can use a separate path for each registry to inform `oci-registry` of which registry the request is for.
+
 ### Configure `oci-registry`
 `oci-registry`'s default configuration is to mirror any registry for which it receives requests, connecting to upstream with HTTPS, rejecting invalid certs, and using the namespace as the upstream registry host - e.g. requests for `gcr.io` images will be made to https://gcr.io/ - with the exception of `docker.io`, which will be pointed to https://registry-1.docker.io
 
@@ -102,6 +105,26 @@ EOF
 
 The above example will configure `containerd` to attempt to pull `docker.io` and `gcr.io` manifests and blobs from `oci-registry` listening on `localhost:8080`, while sticking with the original hosts for pushing, and using the original hosts if something goes wrong with `oci-registry`.
 
+### Configure `cri-o`
+`cri-o` uses the common [`registries.conf`][registries-conf] configuration file to specify which registries to mirror.
+
+Assuming default paths, simply add the following to `/etc/containers/registries.conf`:
+```
+[[registry]]
+location = "docker.io"
+[[registry.mirror]]
+location = "localhost:8080/docker.io"
+insecure = true
+
+[[registry]]
+location = "gcr.io"
+[[registry.mirror]]
+location = "localhost:8080/gcr.io"
+insecure = true
+```
+
+The above example will configure `cri-o` to attempt to pull `docker.io` and `gcr.io` manifests and blobs from `oci-registry` listening on `localhost:8080`, while sticking with the original hosts for pushing, and using the original hosts if something goes wrong with `oci-registry`.
+
 # Community
 The Github repo is a mirror.  Project management is done in the [main repo][gitlab].  In addition, there is a [Matrix room][matrix].
 
@@ -110,6 +133,7 @@ The Github repo is a mirror.  Project management is done in the [main repo][gitl
 [oci-test-suite]: https://github.com/opencontainers/distribution-spec/tree/main/conformance
 [containerd-hosts]: https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 [containerd-deprecated]: https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-endpoint
+[registries-conf]: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md
 [gitlab]: https://gitlab.cronce.io/foss/oci-registry
 [matrix]: https://matrix.to/#/%23oci-registry%3Acronce.io
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The Github repo is a mirror.  Project management is done in the [main repo][gitl
 [oci-test-suite]: https://github.com/opencontainers/distribution-spec/tree/main/conformance
 [containerd-hosts]: https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 [containerd-deprecated]: https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-endpoint
-[registries-conf]: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md
+[registries-conf]: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#remapping-and-mirroring-registries
 [gitlab]: https://gitlab.cronce.io/foss/oci-registry
 [matrix]: https://matrix.to/#/%23oci-registry%3Acronce.io
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -54,16 +54,12 @@ pub async fn root(config: web::Data<RequestConfig>, qstr: web::Query<ManifestQue
 
 #[derive(Debug, Deserialize)]
 pub struct ManifestRequest {
-	namespace: Option<CompactString>,
 	image: ImageName,
 	reference: ImageReference
 }
 
 impl ManifestRequest {
 	fn http_path(&self) -> String {
-		if self.namespace.is_some() {
-			return format!("/{}/{}/manifests/{}", self.namespace.as_deref().unwrap(), self.image, self.reference)
-		}
 		format!("/{}/manifests/{}", self.image, self.reference)
 	}
 
@@ -90,7 +86,7 @@ pub async fn manifest(req: web::Path<ManifestRequest>, qstr: web::Query<Manifest
 	static HIT_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| register_int_counter_vec!("manifest_cache_hits", "Number of manifests read from cache", &["namespace"]).unwrap());
 	static MISS_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| register_int_counter_vec!("manifest_cache_misses", "Number of manifest requests that went to upstream", &["namespace"]).unwrap());
 
-	let namespace = qstr.ns.as_deref().unwrap_or_else(|| req.namespace.as_deref().unwrap_or_else(|| config.default_ns.as_ref()));
+	let namespace = qstr.ns.as_deref().unwrap_or_else(|| req.image.as_ref().split("/").next().unwrap_or_else(|| config.default_ns.as_ref()));
 
 	let max_age = config.upstream.lock().await.get(namespace)?.manifest_invalidation_time;
 	let storage_path = req.storage_path(namespace);
@@ -129,16 +125,12 @@ pub async fn manifest(req: web::Path<ManifestRequest>, qstr: web::Query<Manifest
 
 #[derive(Debug, Deserialize)]
 pub struct BlobRequest {
-	namespace: Option<CompactString>,
 	image: ImageName,
 	digest: String
 }
 
 impl BlobRequest {
 	fn http_path(&self) -> String {
-		if self.namespace.is_some() {
-			return format!("/{}/{}/blobs/{}", self.namespace.as_deref().unwrap(), self.image, self.digest)
-		}
 		format!("/{}/blobs/{}", self.image, self.digest)
 	}
 
@@ -158,7 +150,7 @@ pub async fn blob(req: web::Path<BlobRequest>, qstr: web::Query<ManifestQueryStr
 		return Err(Error::InvalidDigest);
 	}
 
-	let namespace = qstr.ns.as_deref().unwrap_or_else(|| req.namespace.as_deref().unwrap_or_else(|| config.default_ns.as_ref()));
+	let namespace = qstr.ns.as_deref().unwrap_or_else(|| req.image.as_ref().split("/").next().unwrap_or_else(|| config.default_ns.as_ref()));
 
 	let storage_path = req.storage_path();
 	let max_age = config.upstream.lock().await.get(namespace)?.blob_invalidation_time;

--- a/src/api.rs
+++ b/src/api.rs
@@ -68,9 +68,6 @@ impl ManifestRequest {
 	}
 
 	fn storage_path(&self, ns: &str) -> String {
-		if self.namespace.is_some() {
-			return format!("manifests/{:?}/{}/{}", self.namespace, self.image, self.reference)
-		}
 		format!("manifests/{}/{}/{}", ns, self.image, self.reference)
 	}
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -90,7 +90,7 @@ pub async fn manifest(req: web::Path<ManifestRequest>, qstr: web::Query<Manifest
 	static MISS_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| register_int_counter_vec!("manifest_cache_misses", "Number of manifest requests that went to upstream", &["namespace"]).unwrap());
 
 	let mut namespace = qstr.ns.as_deref().unwrap_or_else(|| config.default_ns.as_ref());
-	let mut image: &str = req.image.as_ref().trim_start_matches("docker.io/");
+	let mut image: &str = req.image.as_ref();
 	if req.image.as_ref().split("/").count() > 2 {
 		namespace = req.image.as_ref().split("/").next().unwrap_or_else(|| config.default_ns.as_ref());
 		image = req.image.as_ref().trim_start_matches(req.image.as_ref().split("/").next().unwrap_or_default()).trim_start_matches("/");
@@ -159,7 +159,7 @@ pub async fn blob(req: web::Path<BlobRequest>, qstr: web::Query<ManifestQueryStr
 	}
 
 	let mut namespace = qstr.ns.as_deref().unwrap_or_else(|| config.default_ns.as_ref());
-	let mut image: &str = req.image.as_ref().trim_start_matches("docker.io/");
+	let mut image: &str = req.image.as_ref();
 	if req.image.as_ref().split("/").count() > 2 {
 		namespace = req.image.as_ref().split("/").next().unwrap_or_else(|| config.default_ns.as_ref());
 		image = req.image.as_ref().trim_start_matches(req.image.as_ref().split("/").next().unwrap_or_default()).trim_start_matches("/");

--- a/src/api.rs
+++ b/src/api.rs
@@ -97,7 +97,7 @@ pub async fn manifest(req: web::Path<ManifestRequest>, qstr: web::Query<Manifest
 	static MISS_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| register_int_counter_vec!("manifest_cache_misses", "Number of manifest requests that went to upstream", &["namespace"]).unwrap());
 
 	let (namespace, image) = match qstr.ns.as_deref() {
-		Some(ns) => (ns, req.image.as_ref().trim_start_matches(&format!("{}/", ns))),
+		Some(ns) => (ns, req.image.as_ref()),
 		None => {
 			let mut parts = req.image.as_ref().splitn(2, '/');
 			match (parts.next(), parts.next()) {
@@ -173,7 +173,7 @@ pub async fn blob(req: web::Path<BlobRequest>, qstr: web::Query<ManifestQueryStr
 	}
 
 	let (namespace, image) = match qstr.ns.as_deref() {
-		Some(ns) => (ns, req.image.as_ref().trim_start_matches(&format!("{}/", ns))),
+		Some(ns) => (ns, req.image.as_ref()),
 		None => {
 			let mut parts = req.image.as_ref().splitn(2, '/');
 			match (parts.next(), parts.next()) {

--- a/src/api.rs
+++ b/src/api.rs
@@ -90,11 +90,12 @@ pub async fn manifest(req: web::Path<ManifestRequest>, qstr: web::Query<Manifest
 	static MISS_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| register_int_counter_vec!("manifest_cache_misses", "Number of manifest requests that went to upstream", &["namespace"]).unwrap());
 
 	let mut namespace = qstr.ns.as_deref().unwrap_or_else(|| config.default_ns.as_ref());
+	let mut image: &str = req.image.as_ref().trim_start_matches("docker.io/");
 	if req.image.as_ref().split("/").count() > 2 {
 		namespace = req.image.as_ref().split("/").next().unwrap_or_else(|| config.default_ns.as_ref());
+		image = req.image.as_ref().trim_start_matches(req.image.as_ref().split("/").next().unwrap_or_default()).trim_start_matches("/");
 	}
 
-	let image: &str = req.image.as_ref().trim_start_matches("docker.io/");
 	let max_age = config.upstream.lock().await.get(namespace)?.manifest_invalidation_time;
 	let storage_path = req.storage_path(namespace);
 	match config.repo.read(&storage_path, max_age).await {
@@ -158,11 +159,12 @@ pub async fn blob(req: web::Path<BlobRequest>, qstr: web::Query<ManifestQueryStr
 	}
 
 	let mut namespace = qstr.ns.as_deref().unwrap_or_else(|| config.default_ns.as_ref());
+	let mut image: &str = req.image.as_ref().trim_start_matches("docker.io/");
 	if req.image.as_ref().split("/").count() > 2 {
 		namespace = req.image.as_ref().split("/").next().unwrap_or_else(|| config.default_ns.as_ref());
+		image = req.image.as_ref().trim_start_matches(req.image.as_ref().split("/").next().unwrap_or_default()).trim_start_matches("/");
 	}
 
-	let image: &str = req.image.as_ref().trim_start_matches("docker.io/");
 	let storage_path = req.storage_path();
 	let max_age = config.upstream.lock().await.get(namespace)?.blob_invalidation_time;
 	match config.repo.read(storage_path.as_ref(), max_age).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,18 +115,18 @@ async fn main() {
 				web::scope("/v2")
 					.wrap(actix_web::middleware::Logger::default())
 					.route("/", web::get().to(api::root))
-					// /v2/library/telegraf/manifests/1.24-alpine
-					// /v2/library/redis/manifests/sha256:226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883
-					.route("/{image:[^{}]+}/manifests/{reference}", web::head().to(api::manifest))
-					.route("/{image:[^{}]+}/manifests/{reference}", web::get().to(api::manifest))
 					// /v2/docker.io/library/telegraf/manifests/1.24-alpine
 					// /v2/docker.io/library/redis/manifests/sha256:226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883
 					.route("/{namespace}/{image:[^{}]+}/manifests/{reference}", web::head().to(api::manifest))
 					.route("/{namespace}/{image:[^{}]+}/manifests/{reference}", web::get().to(api::manifest))
-					// /v2/grafana/grafana/blobs/sha256:6864e61916f58174557076c34e7122753331cf28077edb0f23e1fb5419dd6acd
-					.route("/{image:[^{}]+}/blobs/{digest}", web::get().to(api::blob))
+					// /v2/library/telegraf/manifests/1.24-alpine
+					// /v2/library/redis/manifests/sha256:226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883
+					.route("/{image:[^{}]+}/manifests/{reference}", web::head().to(api::manifest))
+					.route("/{image:[^{}]+}/manifests/{reference}", web::get().to(api::manifest))
 					// /v2/docker.io/grafana/grafana/blobs/sha256:6864e61916f58174557076c34e7122753331cf28077edb0f23e1fb5419dd6acd
 					.route("/{namespace}/{image:[^{}]+}/blobs/{digest}", web::get().to(api::blob))
+					// /v2/grafana/grafana/blobs/sha256:6864e61916f58174557076c34e7122753331cf28077edb0f23e1fb5419dd6acd
+					.route("/{image:[^{}]+}/blobs/{digest}", web::get().to(api::blob))
 					.wrap_fn(|req, srv| {
 						srv.call(req).map(|response| {
 							response.map(|mut ok| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,8 +119,14 @@ async fn main() {
 					// /v2/library/redis/manifests/sha256:226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883
 					.route("/{image:[^{}]+}/manifests/{reference}", web::head().to(api::manifest))
 					.route("/{image:[^{}]+}/manifests/{reference}", web::get().to(api::manifest))
+					// /v2/docker.io/library/telegraf/manifests/1.24-alpine
+					// /v2/docker.io/library/redis/manifests/sha256:226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883
+					.route("/{namespace}/{image:[^{}]+}/manifests/{reference}", web::head().to(api::manifest))
+					.route("/{namespace}/{image:[^{}]+}/manifests/{reference}", web::get().to(api::manifest))
 					// /v2/grafana/grafana/blobs/sha256:6864e61916f58174557076c34e7122753331cf28077edb0f23e1fb5419dd6acd
 					.route("/{image:[^{}]+}/blobs/{digest}", web::get().to(api::blob))
+					// /v2/docker.io/grafana/grafana/blobs/sha256:6864e61916f58174557076c34e7122753331cf28077edb0f23e1fb5419dd6acd
+					.route("/{namespace}/{image:[^{}]+}/blobs/{digest}", web::get().to(api::blob))
 					.wrap_fn(|req, srv| {
 						srv.call(req).map(|response| {
 							response.map(|mut ok| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,17 +115,14 @@ async fn main() {
 				web::scope("/v2")
 					.wrap(actix_web::middleware::Logger::default())
 					.route("/", web::get().to(api::root))
-					// /v2/docker.io/library/telegraf/manifests/1.24-alpine
-					// /v2/docker.io/library/redis/manifests/sha256:226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883
-					.route("/{namespace}/{image:[^{}]+}/manifests/{reference}", web::head().to(api::manifest))
-					.route("/{namespace}/{image:[^{}]+}/manifests/{reference}", web::get().to(api::manifest))
 					// /v2/library/telegraf/manifests/1.24-alpine
 					// /v2/library/redis/manifests/sha256:226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883
+					// /v2/docker.io/library/telegraf/manifests/1.24-alpine
+					// /v2/docker.io/library/redis/manifests/sha256:226cbafc637cd58cf008bf87ec9d1548ad1b672ef4279433495bdff100cdb883
 					.route("/{image:[^{}]+}/manifests/{reference}", web::head().to(api::manifest))
 					.route("/{image:[^{}]+}/manifests/{reference}", web::get().to(api::manifest))
-					// /v2/docker.io/grafana/grafana/blobs/sha256:6864e61916f58174557076c34e7122753331cf28077edb0f23e1fb5419dd6acd
-					.route("/{namespace}/{image:[^{}]+}/blobs/{digest}", web::get().to(api::blob))
 					// /v2/grafana/grafana/blobs/sha256:6864e61916f58174557076c34e7122753331cf28077edb0f23e1fb5419dd6acd
+					// /v2/docker.io/grafana/grafana/blobs/sha256:6864e61916f58174557076c34e7122753331cf28077edb0f23e1fb5419dd6acd
 					.route("/{image:[^{}]+}/blobs/{digest}", web::get().to(api::blob))
 					.wrap_fn(|req, srv| {
 						srv.call(req).map(|response| {

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -24,8 +24,7 @@ pub struct Client {
 
 pub struct Clients(HashMap<CompactString, Client>);
 impl Clients {
-	pub fn get<'a>(&'a mut self, key: Option<&str>) -> Result<&'a mut Client, Error> {
-		let key = key.unwrap_or_default();
+	pub fn get<'a>(&'a mut self, key: &str) -> Result<&'a mut Client, Error> {
 		if (!self.0.contains_key(key)) {
 			warn!("Unknown namespace '{}' passed; configuring with default settings", key);
 			self.insert(key.into(), SingleUpstreamConfig::new(key.into()))?;
@@ -226,7 +225,7 @@ impl UpstreamConfig {
 			warn!(namespace, "Namespace found in UPSTREAM_CREDENTIALS, but not in upstream config file; will be ignored.");
 		}
 
-		let default_client = clients.get(Some(&self.default_upstream_namespace))?.clone();
+		let default_client = clients.get(&self.default_upstream_namespace)?.clone();
 		clients.0.insert("".into(), default_client);
 		Ok(clients)
 	}

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -19,7 +19,7 @@ use crate::util::SecretString;
 pub struct Client {
 	pub client: InnerClient,
 	pub manifest_invalidation_time: core::time::Duration,
-	pub blob_invalidation_time: core::time::Duration
+	pub blob_invalidation_time: core::time::Duration,
 }
 
 pub struct Clients(HashMap<CompactString, Client>);
@@ -40,7 +40,7 @@ impl Clients {
 	pub fn invalidation_config(&self) -> InvalidationConfig {
 		let mut config = InvalidationConfig {
 			blob: core::time::Duration::from_secs(10),
-			manifests: HashMap::with_capacity(self.0.len())
+			manifests: HashMap::with_capacity(self.0.len()),
 		};
 		for (ns, client) in self.0.iter() {
 			if (ns.is_empty()) {
@@ -64,7 +64,7 @@ impl FromIterator<(CompactString, Client)> for Clients {
 #[derive(Clone, Debug)]
 pub struct InvalidationConfig {
 	pub blob: core::time::Duration,
-	pub manifests: HashMap<CompactString, core::time::Duration>
+	pub manifests: HashMap<CompactString, core::time::Duration>,
 }
 
 const fn truth() -> bool {
@@ -99,7 +99,7 @@ pub struct SingleUpstreamConfig {
 	manifest_invalidation_time: Duration,
 	#[serde(default = "default_blob_invalidation_time")]
 	#[serde_as(as = "DisplayFromStr")]
-	blob_invalidation_time: Duration
+	blob_invalidation_time: Duration,
 }
 
 impl SingleUpstreamConfig {
@@ -117,7 +117,7 @@ impl SingleUpstreamConfig {
 			username: None,
 			password: None,
 			manifest_invalidation_time: default_manifest_invalidation_time(),
-			blob_invalidation_time: default_blob_invalidation_time()
+			blob_invalidation_time: default_blob_invalidation_time(),
 		}
 	}
 }
@@ -137,7 +137,7 @@ impl TryFrom<SingleUpstreamConfig> for Client {
 		Ok(Self {
 			client,
 			manifest_invalidation_time: config.manifest_invalidation_time.into(),
-			blob_invalidation_time: config.blob_invalidation_time.into()
+			blob_invalidation_time: config.blob_invalidation_time.into(),
 		})
 	}
 }
@@ -161,13 +161,13 @@ pub struct UpstreamConfig {
 	///
 	/// Example: `{"docker.io": {"username": "foo", "password": "bar"}, "namespace2": {"username":
 	/// {"aaa", "pasword": "bbb"}}`
-	upstream_credentials: String
+	upstream_credentials: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct CredentialsOverride<'a> {
 	username: &'a str,
-	password: &'a str
+	password: &'a str,
 }
 
 impl UpstreamConfig {
@@ -193,7 +193,7 @@ impl UpstreamConfig {
 							conf.password = Some(cred.password.into());
 							conf
 						},
-						None => conf
+						None => conf,
 					})
 					.map(|conf| Ok::<_, Error>((conf.namespace.clone(), conf.try_into()?)))
 					.collect::<Result<Clients, _>>()?
@@ -201,7 +201,7 @@ impl UpstreamConfig {
 			None => {
 				let (username, password) = match upstream_credentials.remove("docker.io") {
 					Some(creds) => (Some(creds.username.into()), Some(creds.password.into())),
-					None => (None, None)
+					None => (None, None),
 				};
 				#[rustfmt::skip]
 				let client = SingleUpstreamConfig{
@@ -218,7 +218,7 @@ impl UpstreamConfig {
 				let mut map = HashMap::with_capacity(1);
 				map.insert("docker.io".into(), client);
 				Clients(map)
-			}
+			},
 		};
 
 		for (namespace, _) in upstream_credentials {

--- a/test.sh
+++ b/test.sh
@@ -22,12 +22,6 @@ test() {
 
   rm -rf /tmp/oci-mirror
 
-  # Combination of both (shouldn't actually be used but doesn't hurt to test)
-  url="localhost:8080/v2/$1/$2?ns=$1"
-  curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
-
-  rm -rf /tmp/oci-mirror
-
   # Special Docker Hub case falling back to default_ns
   if [ "$1" == "docker.io" ]; then
     url="localhost:8080/v2/$2"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Expects oci-registry to be listening on localhost:8080, for example:
+# RUST_LOG=info,actix-web=debug cargo run -- --listen 0.0.0.0:8080 filesystem --root /tmp/oci-mirror
+
+set -eu
+
+test() {
+  echo "--- Testing $1/$2"
+
+  # containerd
+  url="localhost:8080/v2/$2?ns=$1"
+  curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
+
+  rm -rf /tmp/oci-mirror
+
+  # cri-o
+  url="localhost:8080/v2/$1/$2"
+  curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
+
+  rm -rf /tmp/oci-mirror
+
+  # Combination of both (shouldn't actually be used but doesn't hurt to test)
+  url="localhost:8080/v2/$1/$2?ns=$1"
+  curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
+
+  rm -rf /tmp/oci-mirror
+
+  # Special Docker Hub case using default_ns
+  if [ "$1" = "docker.io" ]; then
+    url="localhost:8080/v2/$2"
+    curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
+  fi
+}
+
+test 'docker.io' 'envoyproxy/envoy/manifests/v1.26.2'
+test 'docker.io' 'library/busybox/manifests/latest'
+test 'docker.io' 'grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3'
+
+test 'gcr.io' 'distroless/static/manifests/latest'
+test 'gcr.io' 'distroless/static/blobs/sha256:fe5ca62666f04366c8e7f605aa82997d71320183e99962fa76b3209fdfbb8b58'
+test 'gcr.io' 'flame-public/buildbuddy-app-onprem/manifests/sha256:68932b6227b4c16d6bbc08997620284ef71f7b10ee9b9dc47b631ae92f31a6a3'
+
+test 'ghcr.io' 'buildbarn/bb-runner-installer/manifests/sha256:beb72a39662a613a889f17e7a15254f7e03849e4f7000f399ea7bdabe4a25f79'
+test 'ghcr.io' 'buildbarn/bb-runner-installer/blobs/sha256:e2334dd9fee4b77e48a8f2d793904118a3acf26f1f2e72a3d79c6cae993e07f0'

--- a/test.sh
+++ b/test.sh
@@ -28,8 +28,8 @@ test() {
 
   rm -rf /tmp/oci-mirror
 
-  # Special Docker Hub case using default_ns
-  if [ "$1" = "docker.io" ]; then
+  # Special Docker Hub case falling back to default_ns
+  if [ "$1" == "docker.io" ]; then
     url="localhost:8080/v2/$2"
     curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
   fi

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,8 @@ set -eu
 test() {
   echo "--- Testing $1/$2"
 
+  rm -rf /tmp/oci-mirror
+
   # containerd
   url="localhost:8080/v2/$2?ns=$1"
   curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"


### PR DESCRIPTION
Fixes #15
Fixes #16

This adds support for paths that have a path prefix of the namespace instead of the `ns` param.

Tested using the new simple test script I added in:
```
./test.sh
--- Testing docker.io/envoyproxy/envoy/manifests/v1.26.2
  200: localhost:8080/v2/envoyproxy/envoy/manifests/v1.26.2?ns=docker.io
  200: localhost:8080/v2/docker.io/envoyproxy/envoy/manifests/v1.26.2
  200: localhost:8080/v2/envoyproxy/envoy/manifests/v1.26.2
--- Testing docker.io/library/busybox/manifests/latest
  200: localhost:8080/v2/library/busybox/manifests/latest?ns=docker.io
  200: localhost:8080/v2/docker.io/library/busybox/manifests/latest
  200: localhost:8080/v2/library/busybox/manifests/latest
--- Testing docker.io/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3
  200: localhost:8080/v2/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3?ns=docker.io
  200: localhost:8080/v2/docker.io/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3
  200: localhost:8080/v2/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3
--- Testing gcr.io/distroless/static/manifests/latest
  200: localhost:8080/v2/distroless/static/manifests/latest?ns=gcr.io
  200: localhost:8080/v2/gcr.io/distroless/static/manifests/latest
--- Testing gcr.io/distroless/static/blobs/sha256:fe5ca62666f04366c8e7f605aa82997d71320183e99962fa76b3209fdfbb8b58
  200: localhost:8080/v2/distroless/static/blobs/sha256:fe5ca62666f04366c8e7f605aa82997d71320183e99962fa76b3209fdfbb8b58?ns=gcr.io
  200: localhost:8080/v2/gcr.io/distroless/static/blobs/sha256:fe5ca62666f04366c8e7f605aa82997d71320183e99962fa76b3209fdfbb8b58
--- Testing gcr.io/flame-public/buildbuddy-app-onprem/manifests/sha256:68932b6227b4c16d6bbc08997620284ef71f7b10ee9b9dc47b631ae92f31a6a3
  200: localhost:8080/v2/flame-public/buildbuddy-app-onprem/manifests/sha256:68932b6227b4c16d6bbc08997620284ef71f7b10ee9b9dc47b631ae92f31a6a3?ns=gcr.io
  200: localhost:8080/v2/gcr.io/flame-public/buildbuddy-app-onprem/manifests/sha256:68932b6227b4c16d6bbc08997620284ef71f7b10ee9b9dc47b631ae92f31a6a3
--- Testing ghcr.io/buildbarn/bb-runner-installer/manifests/sha256:beb72a39662a613a889f17e7a15254f7e03849e4f7000f399ea7bdabe4a25f79
  200: localhost:8080/v2/buildbarn/bb-runner-installer/manifests/sha256:beb72a39662a613a889f17e7a15254f7e03849e4f7000f399ea7bdabe4a25f79?ns=ghcr.io
  200: localhost:8080/v2/ghcr.io/buildbarn/bb-runner-installer/manifests/sha256:beb72a39662a613a889f17e7a15254f7e03849e4f7000f399ea7bdabe4a25f79
--- Testing ghcr.io/buildbarn/bb-runner-installer/blobs/sha256:e2334dd9fee4b77e48a8f2d793904118a3acf26f1f2e72a3d79c6cae993e07f0
  200: localhost:8080/v2/buildbarn/bb-runner-installer/blobs/sha256:e2334dd9fee4b77e48a8f2d793904118a3acf26f1f2e72a3d79c6cae993e07f0?ns=ghcr.io
  200: localhost:8080/v2/ghcr.io/buildbarn/bb-runner-installer/blobs/sha256:e2334dd9fee4b77e48a8f2d793904118a3acf26f1f2e72a3d79c6cae993e07f0
```

The directory layout is now fixed as well 🎉 
```
tree /tmp/oci-mirror
/tmp/oci-mirror
├── blobs
│   └── sha256
│       ├── 31
│       │   └── e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3
│       ├── e2
│       │   └── 334dd9fee4b77e48a8f2d793904118a3acf26f1f2e72a3d79c6cae993e07f0
│       └── fe
│           └── 5ca62666f04366c8e7f605aa82997d71320183e99962fa76b3209fdfbb8b58
└── manifests
    ├── docker.io
    │   ├── envoyproxy
    │   │   └── envoy
    │   │       └── v1.26.2
    │   └── library
    │       └── busybox
    │           └── latest
    ├── gcr.io
    │   ├── distroless
    │   │   └── static
    │   │       └── latest
    │   └── flame-public
    │       └── buildbuddy-app-onprem
    │           └── sha256:68932b6227b4c16d6bbc08997620284ef71f7b10ee9b9dc47b631ae92f31a6a3
    └── ghcr.io
        └── buildbarn
            └── bb-runner-installer
                └── sha256:beb72a39662a613a889f17e7a15254f7e03849e4f7000f399ea7bdabe4a25f79

20 directories, 8 files
```