### PR TITLE
increase latency buckets, add chunk read/write metrics and timeouts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,10 +41,10 @@ struct Config {
 	/// blob needs to be read from storage twice instead of just once.
 	#[clap(env, long, default_value_t = false)]
 	check_cache_digest: bool,
-	#[clap(env, long, default_value = "30s")]
-	blob_chunk_read_timeout: Duration,
-	#[clap(env, long, default_value = "30s")]
-	blob_chunk_write_timeout: Duration,
+	#[clap(env, long, default_value_t = 30)]
+	blob_chunk_read_timeout_seconds: u64,
+	#[clap(env, long, default_value_t = 30)]
+	blob_chunk_write_timeout_seconds: u64,
 	#[clap(flatten)]
 	upstream: UpstreamConfig,
 	#[clap(subcommand)]
@@ -121,8 +121,8 @@ async fn main() {
 		upstream,
 		config.default_namespace,
 		config.check_cache_digest,
-		config.blob_chunk_read_timeout,
-		config.blob_chunk_write_timeout,
+		Duration::from_secs(config.blob_chunk_read_timeout_seconds),
+		Duration::from_secs(config.blob_chunk_write_timeout_seconds),
 	));
 
 	let server = actix_web::HttpServer::new(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,14 @@ async fn main() {
 		.buckets(&[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0])
 		.build()
 		.unwrap();
-	let per_request_config = web::Data::new(api::RequestConfig::new(repo, upstream, config.default_namespace, config.check_cache_digest));
+	let per_request_config = web::Data::new(api::RequestConfig::new(
+		repo,
+		upstream,
+		config.default_namespace,
+		config.check_cache_digest,
+		config.blob_chunk_read_timeout,
+		config.blob_chunk_write_timeout,
+	));
 
 	let server = actix_web::HttpServer::new(move || {
 		actix_web::App::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,10 +41,10 @@ struct Config {
 	/// blob needs to be read from storage twice instead of just once.
 	#[clap(env, long, default_value_t = false)]
 	check_cache_digest: bool,
-	#[clap(env, long, default_value_t = 30)]
-	blob_chunk_read_timeout_seconds: u64,
-	#[clap(env, long, default_value_t = 30)]
-	blob_chunk_write_timeout_seconds: u64,
+	#[clap(env, long, default_value_t = 10)]
+	blob_first_chunk_read_timeout_seconds: u64,
+	#[clap(env, long, default_value_t = 10)]
+	blob_first_chunk_write_timeout_seconds: u64,
 	#[clap(flatten)]
 	upstream: UpstreamConfig,
 	#[clap(subcommand)]
@@ -121,8 +121,8 @@ async fn main() {
 		upstream,
 		config.default_namespace,
 		config.check_cache_digest,
-		Duration::from_secs(config.blob_chunk_read_timeout_seconds),
-		Duration::from_secs(config.blob_chunk_write_timeout_seconds),
+		Duration::from_secs(config.blob_first_chunk_read_timeout_seconds),
+		Duration::from_secs(config.blob_first_chunk_write_timeout_seconds),
 	));
 
 	let server = actix_web::HttpServer::new(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ async fn main() {
 
 	let prometheus = PrometheusMetricsBuilder::new("http")
 		.endpoint("/metrics")
-		.buckets(&[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0])
+		.buckets(&[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 180.0, 240.0, 300.0])
 		.build()
 		.unwrap();
 	let per_request_config = web::Data::new(api::RequestConfig::new(

--- a/test.sh
+++ b/test.sh
@@ -12,20 +12,20 @@ test() {
 
   # containerd
   url="localhost:8080/v2/$2?ns=$1"
-  curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
+  curl -sS -o /dev/null -w "  %{http_code}: $url\n" "$url"
 
   rm -rf /tmp/oci-mirror
 
   # cri-o
   url="localhost:8080/v2/$1/$2"
-  curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
+  curl -sS -o /dev/null -w "  %{http_code}: $url\n" "$url"
 
   rm -rf /tmp/oci-mirror
 
   # Special Docker Hub case falling back to default_ns
   if [ "$1" == "docker.io" ]; then
     url="localhost:8080/v2/$2"
-    curl -s -o /dev/null -w "  %{http_code}: $url\n" "$url"
+    curl -sS -o /dev/null -w "  %{http_code}: $url\n" "$url"
   fi
 }
 


### PR DESCRIPTION
- Increases the latency buckets for the built-in prometheus metrics to record up to 5 minutes
- Adds chunk read/write latency metrics
- Adds chunk read/write timeouts and metrics for when they occur


Lowered the timeout to `0.001` seconds, set Network Link Conditioner to 3G, and voila:
```
--- Testing docker.io/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3
  504: localhost:8080/v2/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3?ns=docker.io
  504: localhost:8080/v2/docker.io/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3
  504: localhost:8080/v2/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3
```

```
2024-06-07T22:43:30.799714Z  WARN oci_registry::api: Blob not found in repository; pulling from upstream path="blobs/sha256/31/e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3" error=I/O error: No such file or directory (os error 2)
2024-06-07T22:43:32.879865Z ERROR oci_registry::api: Timeout while reading first blob chunk path="/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3"
2024-06-07T22:43:32.880587Z ERROR oci_registry::api::error: 504: Timeout while reading first blob chunk
2024-06-07T22:43:32.882815Z  INFO actix_web::middleware::logger: 127.0.0.1 "GET /v2/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3?ns=docker.io HTTP/1.1" 504 38 "-" "curl/8.6.0" 2.083724
2024-06-07T22:43:32.918662Z  WARN oci_registry::api: Blob not found in repository; pulling from upstream path="blobs/sha256/31/e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3" error=I/O error: No such file or directory (os error 2)
2024-06-07T22:43:35.819044Z ERROR oci_registry::api: Timeout while reading first blob chunk path="/docker.io/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3"
2024-06-07T22:43:35.819689Z ERROR oci_registry::api::error: 504: Timeout while reading first blob chunk
2024-06-07T22:43:35.826760Z  INFO actix_web::middleware::logger: 127.0.0.1 "GET /v2/docker.io/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3 HTTP/1.1" 504 38 "-" "curl/8.6.0" 2.909199
2024-06-07T22:43:35.855841Z  WARN oci_registry::api: Blob not found in repository; pulling from upstream path="blobs/sha256/31/e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3" error=I/O error: No such file or directory (os error 2)
2024-06-07T22:43:39.965011Z ERROR oci_registry::api: Timeout while reading first blob chunk path="/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3"
2024-06-07T22:43:39.965152Z ERROR oci_registry::api::error: 504: Timeout while reading first blob chunk
2024-06-07T22:43:39.967256Z  INFO actix_web::middleware::logger: 127.0.0.1 "GET /v2/grafana/mimirtool/blobs/sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3 HTTP/1.1" 504 38 "-" "curl/8.6.0" 4.112352
```